### PR TITLE
Build as UMD module and test in AMD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ test:
 
 d3-selection.js: $(shell node_modules/.bin/browserify standalone.js --list)
 	rm -f $@
-	node_modules/.bin/browserify standalone.js > $@
+	node_modules/.bin/browserify -s d3Selection standalone.js > $@
 	chmod a-w $@
 
 d3-selection.min.js: d3-selection.js

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "faucet": "0.0",
     "jsdom": "3",
     "tape": "4",
-    "uglify-js": "2"
+    "uglify-js": "2",
+    "requirejs": "2"
   }
 }

--- a/standalone.js
+++ b/standalone.js
@@ -16,3 +16,5 @@ d3.ns = namespace;
 selection.prototype.on = selection.prototype.event;
 selection.prototype.insert = selection.prototype.append;
 selection.prototype.classed = selection.prototype.class;
+
+module.exports = selection;

--- a/test/require/amd-test.js
+++ b/test/require/amd-test.js
@@ -1,0 +1,19 @@
+var tape = require("tape"),
+    path = require("path"),
+    amdRequire = require("requirejs");
+
+tape("can load uncompressed as AMD module", function(test) {
+  var absPath = path.join(__dirname, "../../d3-selection");
+  amdRequire([absPath], function(d3Selection) {
+    test.ok(d3Selection.select);
+    test.end();
+  });
+});
+
+tape("can load compressed as AMD module", function(test) {
+  var absPath = path.join(__dirname, "../../d3-selection.min");
+  amdRequire([absPath], function(d3Selection) {
+    test.ok(d3Selection.select);
+    test.end();
+  });
+});


### PR DESCRIPTION
Added in `--standalone` option to Browserify build.  Updated the
standalone file to return the selection module.  Added a test showing
functionality with AMD.