### PR TITLE
add ES6 module index and expose as jsnext:main

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.4.0",
   "description": "Data-driven DOM manipulation.",
   "main": "d3-selection",
+  "jsnext:main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "https://github.com/d3/d3-selection.git"

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,21 @@
+import mouse from "./mouse";
+import namespace from "./namespace";
+import namespaces from "./namespaces";
+import requote from "./requote";
+import select from "./select";
+import selectAll from "./selectAll";
+import Selection from "./selection";
+import touch from "./touch";
+import touches from "./touches";
+
+export {
+  mouse,
+  namespace,
+  namespaces,
+  requote,
+  select,
+  selectAll,
+  Selection as selection,
+  touch,
+  touches
+};


### PR DESCRIPTION
This PR adds an additional ES6 module that defines the API and exposes it via the `jsnext:main` field. The purpose of `jsnext:main` is to allow ES6 module bundlers to work with the modules natively, rather than via the prebuilt UMD bundle. Currently there isn't much tooling that can take advantage of it, largely because of chickens and eggs, but it's future-proof ('official' package.json fields can't contain colons) and unobtrusive (it doesn't affect browserify/webpack et al).