### PR TITLE
Add selection.context.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ This module implements the core concept of D3: manipulating the DOM by selecting
 
 * The selection.on method has been renamed selection.event. The old name is deprecated but preserved for backwards-compatibility.
 
+* A new selection.context method captures the context of the current node (data and index), allowing a function to be invoked again later in the same context, such as an event listener.
+
 * A new selection.dispatch method dispatches a [custom event](https://dom.spec.whatwg.org/#interface-customevent) of the specified type to all selected elements. Think of it like jQuery’s trigger.
 
 * [Multi-value map](http://bl.ocks.org/mbostock/3305515) variants of selection.attr, selection.style, selection.property, selection.class and selection.on are now implemented as distinct methods in the [d3-selection-multi plugin](https://github.com/d3/d3-selection-multi), rather than overloading the arguments. See [#2109](https://github.com/mbostock/d3/issues/2109).

--- a/src/selection-context.js
+++ b/src/selection-context.js
@@ -1,0 +1,23 @@
+export default function(args) {
+  var n = args.length,
+      m = n >> 1,
+      i = n + 1,
+      j = m,
+      ancestor = this._root,
+      offset = this._depth - m,
+      ancestors = new Array(m),
+      stack = new Array(n);
+
+  while (--j >= 0) {
+    i -= 2, ancestor = ancestor[stack[i] = args[i]];
+    ancestors[j] = j + offset ? ancestor._parent : ancestor;
+  }
+
+  args = null; // allow gc
+
+  return function(callback) {
+    var i = m;
+    while (--i >= 0) stack[i << 1] = ancestors[i].__data__;
+    callback.apply(ancestors[0], stack);
+  };
+};

--- a/src/selection-event.js
+++ b/src/selection-event.js
@@ -15,7 +15,7 @@ export default function(type, listener, capture) {
   var n = arguments.length,
       key = "__on" + type,
       filter,
-      root = this._root;
+      selection = this;
 
   if (n < 2) return (n = this.node()[key]) && n._listener;
 
@@ -24,13 +24,11 @@ export default function(type, listener, capture) {
   if (filter = filterEvents.has(type)) type = filterEvents.get(type);
 
   function add() {
-    var ancestor = root, i = arguments.length >> 1, ancestors = new Array(i);
-    while (--i >= 0) ancestor = ancestor[arguments[(i << 1) + 1]], ancestors[i] = i ? ancestor._parent : ancestor;
-    var l = listenerOf(listener, ancestors, arguments);
-    if (filter) l = filterListenerOf(l);
     remove.call(this);
-    this.addEventListener(type, this[key] = l, l._capture = capture);
+    var l = listenerOf(listener, selection.context(arguments));
+    if (filter) l = filterListenerOf(l);
     l._listener = listener;
+    this.addEventListener(type, this[key] = l, l._capture = capture);
   }
 
   function remove() {
@@ -57,13 +55,12 @@ export default function(type, listener, capture) {
       : (n ? remove : removeAll));
 };
 
-function listenerOf(listener, ancestors, args) {
+function listenerOf(listener, context) {
   return function(event1) {
-    var i = ancestors.length, event0 = event; // Events can be reentrant (e.g., focus).
-    while (--i >= 0) args[i << 1] = ancestors[i].__data__;
-    event = event1;
+    var event0 = event;
+    event = event1; // Events can be reentrant (e.g., focus).
     try {
-      listener.apply(ancestors[0], args);
+      context(listener);
     } finally {
       event = event0;
     }

--- a/src/selection.js
+++ b/src/selection.js
@@ -22,6 +22,7 @@ import selection_append from "./selection-append";
 import selection_remove from "./selection-remove";
 import selection_datum from "./selection-datum";
 import selection_event from "./selection-event";
+import selection_context from "./selection-context";
 import selection_dispatch from "./selection-dispatch";
 
 // When depth = 1, root = [Node, …].
@@ -65,6 +66,7 @@ Selection.prototype = selection.prototype = {
   remove: selection_remove,
   datum: selection_datum,
   event: selection_event,
+  context: selection_context,
   on: selection_event, // deprecated alias
   dispatch: selection_dispatch
 };

--- a/test/selection-context-test.js
+++ b/test/selection-context-test.js
@@ -1,0 +1,77 @@
+var tape = require("tape"),
+    jsdom = require("jsdom"),
+    d3 = require("../build/d3");
+
+tape("selection.context can capture the context of selection.each", function(test) {
+  var document = jsdom.jsdom("<table><tr><td>Hello</td></tr></table>"),
+      context,
+      results = [],
+      table = document.querySelector("table"),
+      tr = document.querySelector("tr"),
+      td = document.querySelector("td"),
+      s = d3.select(document.body).selectAll("table").selectAll("tr").selectAll("td").datum("foo");
+
+  s.each(function(d, i) {
+    context = s.context(arguments);
+    test.equal(d, "foo", "Doesn’t modify passed arguments.");
+  });
+
+  // Set data after creating the context to verify data is lazily accessed.
+  d3.select(document.body)
+      .datum("body")
+    .selectAll("table")
+      .datum("table")
+    .selectAll("tr")
+      .datum("tr")
+    .selectAll("td")
+      .datum("td");
+
+  context(function() { results.push({this: this, arguments: arguments}); });
+  test.equal(results.length, 1);
+  test.equal(results[0].this, td);
+  test.equal(results[0].arguments.length, 8);
+  test.equal(results[0].arguments[0], "td");
+  test.equal(results[0].arguments[1], 0);
+  test.equal(results[0].arguments[2], "tr");
+  test.equal(results[0].arguments[3], 0);
+  test.equal(results[0].arguments[4], "table");
+  test.equal(results[0].arguments[5], 0);
+  test.equal(results[0].arguments[6], "body");
+  test.equal(results[0].arguments[7], 0);
+  test.end();
+});
+
+tape("selection.context can capture the context of selection.data", function(test) {
+  var document = jsdom.jsdom("<table><tr><td>Hello</td></tr></table>"),
+      context,
+      results = [],
+      table = document.querySelector("table"),
+      tr = document.querySelector("tr"),
+      td = document.querySelector("td"),
+      s = d3.select(document.body).selectAll("table").selectAll("tr").selectAll("td");
+
+  s.data(function() {
+    context = s.context(arguments);
+    return [42];
+  });
+
+  // Set data after creating the context to verify data is lazily accessed.
+  d3.select(document.body)
+      .datum("body")
+    .selectAll("table")
+      .datum("table")
+    .selectAll("tr")
+      .datum("tr");
+
+  context(function() { results.push({this: this, arguments: arguments}); });
+  test.equal(results.length, 1);
+  test.equal(results[0].this, tr);
+  test.equal(results[0].arguments.length, 6);
+  test.equal(results[0].arguments[0], "tr");
+  test.equal(results[0].arguments[1], 0);
+  test.equal(results[0].arguments[2], "table");
+  test.equal(results[0].arguments[3], 0);
+  test.equal(results[0].arguments[4], "body");
+  test.equal(results[0].arguments[5], 0);
+  test.end();
+});

--- a/test/selection-event-test.js
+++ b/test/selection-event-test.js
@@ -16,7 +16,7 @@ tape("selection.event passes the listener function data and index", function(tes
       results = [],
       parent = d3.selectAll(document.querySelectorAll("parent")),
       child = parent.selectAll("child"),
-      s = child.event("foo", function() { results.push({this: this, arguments: [].slice.call(arguments)}); });
+      s = child.event("foo", function() { results.push({this: this, arguments: arguments}); });
   test.equal(results.length, 0);
   parent.datum(function(d, i) { return "parent-" + i; });
   child.datum(function(d, i, p, j) { return "child-" + i + "-" + j; });


### PR DESCRIPTION
I’m not sure about this API. It’s nice to have something that can capture the context of a selection.each (or selection.attr, selection.data, etc.). But it’s a bit weird that you have to pass in `arguments` and then have the selection recompute the ancestors.

Also, sometimes you might want to access the current group or the parent node within a callback. The selection.context can determine those things, but doesn’t expose them.

Also, within a selection.each (or most other selection methods) callback, you don’t have easy access to the current selection because the `this` context is set to the current element. So maybe an approach like d3.event is more suitable? Like, say, d3.context() could be a magic method that only works within selection.each, and returns the context for the current selection.