### PR TITLE
Fixed reference to classedRe in d3.class by 'restoring' it from d3.v3.

### DIFF
--- a/src/selection-class.js
+++ b/src/selection-class.js
@@ -34,7 +34,7 @@ function classerOf(name) {
   var re;
   return function(node, value) {
     if (c = node.classList) return value ? c.add(name) : c.remove(name);
-    if (!re) re = new RegExp("(?:^|\\s+)" + requote(name) + "(?:\\s+|$)", "g");
+    if (!re) re = classedRe(name);
     var c = node.getAttribute("class") || "";
     if (value) {
       re.lastIndex = 0;
@@ -47,4 +47,8 @@ function classerOf(name) {
 
 function collapse(string) {
   return string.trim().replace(/\s+/g, " ");
+}
+
+function classedRe(name) {
+  return new RegExp("(?:^|\\s+)" + requote(name) + "(?:\\s+|$)", "g");
 }

--- a/test/selection-class-test.js
+++ b/test/selection-class-test.js
@@ -1,0 +1,18 @@
+var tape = require("tape"),
+    jsdom = require("jsdom"),
+    d3 = require("../");
+
+tape("d3.class tells you if an element has a class", function(test) {
+  delete global.document;
+
+  var document = jsdom.jsdom("<h1 class=\"c1 c2\">hello</h1>"),
+      s = d3.select(document.body),
+      h  = s.select('h1');
+
+  test.equal(h.class('c1'), true);
+  test.equal(h.class('c2'), true);
+  test.equal(h.class('c3'), false);
+  test.end();
+
+  delete global.document;
+});


### PR DESCRIPTION
`d3.class` (with one parameter, in "check for a class" mode) wasn't working because `classedRe` wasn't defined.

- Fixed reference to `classedRe` in d3.class by 'restoring' it from d3.v3.
- Also updated `classerOf` to use `classedRe` instead of creating the regex directly.
- Added test for d3.class.