### PR TITLE
Avoid assigning to arguments in selection_class

### DIFF
--- a/src/selection-class.js
+++ b/src/selection-class.js
@@ -1,16 +1,17 @@
 import requote from "./requote";
 
-export default function(name, value) {
-  name = (name + "").trim().split(/^|\s+/);
+export default function(rawName, value) {
+  var name = (rawName + "").trim().split(/^|\s+/);
   var n = name.length;
 
   if (arguments.length < 2) {
     var node = this.node(), i = -1;
-    if (value = node.classList) { // SVG elements may not support DOMTokenList!
-      while (++i < n) if (!value.contains(name[i])) return false;
+    var classes = node.classList;
+    if (classes) { // SVG elements may not support DOMTokenList!
+      while (++i < n) if (!classes.contains(name[i])) return false;
     } else {
-      value = node.getAttribute("class");
-      while (++i < n) if (!classedRe(name[i]).test(value)) return false;
+      classes = node.getAttribute("class");
+      while (++i < n) if (!classedRe(name[i]).test(classes)) return false;
     }
     return true;
   }
@@ -29,6 +30,8 @@ export default function(name, value) {
 
   return this.each(typeof value === "function" ? setFunction : setConstant);
 };
+
+
 
 function classerOf(name) {
   var re;


### PR DESCRIPTION
Avoid assigning to arguments so that Chrome can optimize selection_class.

I noticed in the Chrome profiler gives a warning about not being able to optimize `selection_class` because it assigns to the `name` and `value` function parameters.

<img width="1392" alt="screenshot 2015-12-30 13 21 57" src="https://cloud.githubusercontent.com/assets/324298/12055377/a5696906-aefa-11e5-9a2a-226331df6186.png">

So, I created local variables for it to assign to. Doing this resolves the warning, and presumably Chrome can then optimize `selection_class`. (In my case, there was a slight, but not significant, performance improvement.)