### PR TITLE
Added support for `selection.classed()` to accept a function

### DIFF
--- a/src/selection/classed.js
+++ b/src/selection/classed.js
@@ -60,6 +60,16 @@ function classedFunction(names, value) {
 }
 
 export default function(name, value) {
+  
+  var _name = "";
+  if (typeof name === "function") {
+    _name = name();
+    _name = Array.isArray(_name) ? _name.join(" ") : _name.toString();
+  }
+  else {
+    _name = name;
+  }
+
   var names = classArray(name + "");
 
   if (arguments.length < 2) {


### PR DESCRIPTION
This PR adds support for the `selection.classed()` method to accept a function to return the desired class.  Motivation for this was the need to dynamically decide what class to label an element.