### PR TITLE
Remove outdated documentation for local_remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -756,7 +756,7 @@ Returns the value of this local on the specified *node*. If the *node* does not 
 
 <a name="local_remove" href="#local_remove">#</a> <i>local</i>.<b>remove</b>(<i>node</i>) [<>](https://github.com/d3/d3-selection/blob/master/src/local.js#L21 "Source")
 
-Deletes this local’s value from the specified *node* and returns its previous value. Returns true if the *node* defined this local prior to removal, and false otherwise. If ancestors also define this local, those definitions are unaffected, and thus [*local*.get](#local_get) will still return the inherited value.
+Deletes this local’s value from the specified *node*. Returns true if the *node* defined this local prior to removal, and false otherwise. If ancestors also define this local, those definitions are unaffected, and thus [*local*.get](#local_get) will still return the inherited value.
 
 <a name="local_toString" href="#local_toString">#</a> <i>local</i>.<b>toString</b>() [<>](https://github.com/d3/d3-selection/blob/master/src/local.js#L24 "Source")
 


### PR DESCRIPTION
I noticed the documentation said " and returns its previous value", but then went on to say it returns either true or false. Some experimentation revealed it returns either true or false, and never its previous value. It looks like that statement was from a previous iteration of the API and should be removed.