### PR TITLE
guard against missing sourceEvent

### DIFF
--- a/src/point.js
+++ b/src/point.js
@@ -1,4 +1,6 @@
 export default function(node, event) {
+  if (!event) return;
+
   var svg = node.ownerSVGElement || node;
 
   if (svg.createSVGPoint) {


### PR DESCRIPTION
Prevent `SVGPoint.x/y` from being assigned with invalid values. Fixes https://github.com/d3/d3-selection/issues/122