### PR TITLE
Workaround for updated values of 'event' not being properly visible when imported by babel

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,4 +12,4 @@ export {default as selectorAll} from "./src/selectorAll";
 export {default as touch} from "./src/touch";
 export {default as touches} from "./src/touches";
 export {default as window} from "./src/window";
-export {event, customEvent} from "./src/selection/on";
+export {event, customEvent, currentEvent} from "./src/selection/on";

--- a/src/selection/on.js
+++ b/src/selection/on.js
@@ -105,3 +105,7 @@ export function customEvent(event1, listener, that, args) {
     event = event0;
   }
 }
+
+export function currentEvent() {
+  return event;
+}


### PR DESCRIPTION
Hi,

Would you consider adding a getter for the 'event' property (either from this pull request or named differently if this doesn't work with the project's conventions) to ensure it will always work with projects using babel?

None of the solutions previously discussed in [this bug report](https://github.com/d3/d3/issues/2733) have worked for me (and I have successfully tested the getter in my project).