### PR TITLE
Check if event is a function.

### DIFF
--- a/src/selection/dispatch.js
+++ b/src/selection/dispatch.js
@@ -4,7 +4,7 @@ function dispatchEvent(node, type, params) {
   var window = defaultView(node),
       event = window.CustomEvent;
 
-  if (event) {
+  if (typeof event === 'function') {
     event = new event(type, params);
   } else {
     event = window.document.createEvent("Event");

--- a/src/selection/dispatch.js
+++ b/src/selection/dispatch.js
@@ -4,7 +4,7 @@ function dispatchEvent(node, type, params) {
   var window = defaultView(node),
       event = window.CustomEvent;
 
-  if (typeof event === 'function') {
+  if (typeof event === "function") {
     event = new event(type, params);
   } else {
     event = window.document.createEvent("Event");


### PR DESCRIPTION
IE11 has CustomEvent, but it's an object so firing `dispatch` on an
element in IE11 blows up.