### PR TITLE
Expose "Selection" class and constructor directly.

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,6 +7,7 @@ export {default as namespaces} from "./src/namespaces";
 export {default as select} from "./src/select";
 export {default as selectAll} from "./src/selectAll";
 export {default as selection} from "./src/selection/index";
+export {Selection as Selection} from "./src/selection/index";
 export {default as selector} from "./src/selector";
 export {default as selectorAll} from "./src/selectorAll";
 export {styleValue as style} from "./src/selection/style";


### PR DESCRIPTION
This fixes an incompatibility with (or allows us to use) d3 and web-components.  

Background:
d3.{select,selection} always use document.documentElement.querySelector to try and find the element specified. web-components create shadowDoms that hide their internal elements, and prevents document.documentElement.querySelector from finding the element for the selector. 

The easiest way to fix this (as far as I can see) is to allow users to specify their own "parent" elements, and the easiest way to do that (again, as far as I can tell) is to expose the Selection constructor.