### PR TITLE
Add support for d3.select[All](function)

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,15 @@ Selects the first element that matches the specified *selector* string. If no el
 var anchor = d3.select("a");
 ```
 
-If the *selector* is not a string, instead selects the specified node; this is useful if you already have a reference to a node, such as `this` within an event listener or a global such as `document.body`. For example, to make a clicked paragraph red:
+If the *selector* is a function, it is evaluated, with *this* as the `document`.
+
+```js
+var focus = d3.select(function() {
+  return this.activeElement;
+});
+```
+
+If the *selector* is not a string or function, instead selects the specified node; this is useful if you already have a reference to a node, such as `this` within an event listener or a global such as `document.body`. For example, to make a clicked paragraph red:
 
 ```js
 d3.selectAll("p").on("click", function() {
@@ -105,7 +113,15 @@ Selects all elements that match the specified *selector* string. The elements wi
 var paragraph = d3.selectAll("p");
 ```
 
-If the *selector* is not a string, instead selects the specified array of nodes; this is useful if you already have a reference to nodes, such as `this.childNodes` within an event listener or a global such as `document.links`. The nodes may instead be a pseudo-array such as a `NodeList` or `arguments`. For example, to color all links red:
+If the *selector* is a function, it is evaluated, with *this* as the `document`.
+
+```js
+var links = d3.selectAll(function() {
+  return this.links;
+});
+```
+
+If the *selector* is not a string or function, instead selects the specified array of nodes; this is useful if you already have a reference to nodes, such as `this.childNodes` within an event listener or a global such as `document.links`. The nodes may instead be a pseudo-array such as a `NodeList` or `arguments`. For example, to color all links red:
 
 ```js
 d3.selectAll(document.links).style("color", "red");

--- a/src/select.js
+++ b/src/select.js
@@ -3,5 +3,5 @@ import {Selection, root} from "./selection/index";
 export default function(selector) {
   return typeof selector === "string"
       ? new Selection([[document.querySelector(selector)]], [document.documentElement])
-      : new Selection([[selector]], root);
+      : new Selection([[typeof selector === "function" ? selector.call(document) : selector]], root);
 }

--- a/src/selectAll.js
+++ b/src/selectAll.js
@@ -1,7 +1,11 @@
 import {Selection, root} from "./selection/index";
 
 export default function(selector) {
-  return typeof selector === "string"
-      ? new Selection([document.querySelectorAll(selector)], [document.documentElement])
-      : new Selection([selector == null ? [] : selector], root);
+  if (typeof selector === "string") {
+    return new Selection([document.querySelectorAll(selector)], [document.documentElement]);
+  }
+  if (typeof selector === "function") {
+    return new Selection([selector.call(document)], [document]);
+  }
+  return new Selection([selector == null ? [] : selector], root);
 }

--- a/test/select-test.js
+++ b/test/select-test.js
@@ -50,3 +50,10 @@ tape("d3.select(object) selects an arbitrary object", function(test) {
   test.deepEqual(d3.select(object), {_groups: [[object]], _parents: [null]});
   test.end();
 });
+
+tape("d3.select(function) selects the return value of the given function for the document", function(test) {
+  var document = global.document = jsdom("<span id='one'></span>"),
+      one = document.querySelector("#one");
+  test.deepEqual(d3.select(function() { return one; }), {_groups: [[one]], _parents: [null]});
+  test.end();
+});

--- a/test/selectAll-test.js
+++ b/test/selectAll-test.js
@@ -65,3 +65,10 @@ tape("d3.selectAll(array) can select an array that contains arbitrary objects", 
   test.deepEqual(d3.selectAll([object]), {_groups: [[object]], _parents: [null]});
   test.end();
 });
+
+tape("d3.selectAll(function) selects the return values of the given function for the document", function(test) {
+  var document = global.document = jsdom("<span id='one'></span>"),
+      one = document.querySelector("#one");
+  test.deepEqual(d3.selectAll(function() { return [one]; }), {_groups: [[one]], _parents: [document]});
+  test.end();
+});


### PR DESCRIPTION
This checks if the selector provided to d3.select[All] is a function, and if so, calls it on the document.  This squares up the API to be more consistent with selection.select[All], allowing the usage of functions produced by d3.selector at the root.

I'm not entirely clear what purpose selecting a closure would serve, so I think it's reasonable to guess that this won't break any real code, but please do correct me if I'm missing something.

I see that your style elsewhere is nested ternaries, but I just can't do that when the lines are this long.