### PR TITLE
doc(clone): Clarify selection.clone description

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,7 +388,8 @@ Removes the selected elements from the document. Returns this selection (the rem
 
 <a name="selection_clone" href="#selection_clone">#</a> <i>selection</i>.<b>clone</b>([<i>deep</i>]) [<>](https://github.com/d3/d3-selection/blob/master/src/selection/clone.js "Source")
 
-Inserts clones the selected elements immediately following the selected elements. Equivalent to:
+Inserts clones of the selected elements immediately following the selected elements and returns a selection of the newly added clones. 
+If *deep* evaluates to `true`, the child nodes of the selected elements will be cloned as well. Otherwise, only the elements themselves will be cloned. Equivalent to:
 
 ```js
 selection.select(function() {


### PR DESCRIPTION
This changes clarifies the **selection.clone([deep])** API description by:
* adding a description of the return type,
* explaining the optional `deep` parameter.