### PR TITLE
Added selection.apply method

### DIFF
--- a/README.md
+++ b/README.md
@@ -731,7 +731,7 @@ The only difference is that *selection*.call always returns the *selection* and 
 
 <a name="selection_apply" href="#selection_apply">#</a> <i>selection</i>.<b>apply</b>(<i>function</i>[, <i>arguments…</i>]) [<>](https://github.com/d3/d3-selection/blob/master/src/selection/apply.js "Source")
 
-Apply works identically to call, however instead of returning the original selection, it returns the value from the function. This allows for greater flexibility in chaining function calls that return a modified version of the selection, or a new selection entirely. For example, here is a simple transition factory:
+Works identically to `call`, however instead of returning the original selection, it returns the return value from the function. This allows for greater flexibility in chaining function calls that return a modified version of the selection, or a new selection entirely. For example, here is a simple transition factory:
 
 ```js
 function addTransitions (selection) {
@@ -745,7 +745,7 @@ function addTransitions (selection) {
 }
 ```
 
-Using apply, you can call the function on the selection and continue to work on the modified selection like so:
+You can call the function on the selection and continue to work on the modified selection like so:
 
 ```js
 selectAll('.circles')
@@ -754,7 +754,7 @@ selectAll('.circles')
   .attr('r', 50)
 ```
 
-This is equivalent to:
+This is exactly equivalent to:
 
 ```js
 addTransitions(

--- a/README.md
+++ b/README.md
@@ -729,6 +729,42 @@ name(d3.selectAll("div"), "John", "Snow");
 
 The only difference is that *selection*.call always returns the *selection* and not the return value of the called *function*, `name`.
 
+<a name="selection_apply" href="#selection_apply">#</a> <i>selection</i>.<b>apply</b>(<i>function</i>[, <i>arguments…</i>]) [<>](https://github.com/d3/d3-selection/blob/master/src/selection/apply.js "Source")
+
+Apply works identically to call, however instead of returning the original selection, it returns the value from the function. This allows for greater flexibility in chaining function calls that return a modified version of the selection, or a new selection entirely. For example, here is a simple transition factory:
+
+```js
+function addTransitions (selection) {
+  if (useTransitions) {
+    return selection
+      .transition()
+      .duration(duration)
+      .ease(ease)
+  }
+  return selection
+}
+```
+
+Using apply, you can call the function on the selection and continue to work on the modified selection like so:
+
+```js
+selectAll('.circles')
+  .attr('r', 0)
+  .apply(addTransitions)
+  .attr('r', 50)
+```
+
+This is equivalent to:
+
+```js
+addTransitions(
+  selectAll('.circles')
+  .attr('r', 0)
+).attr('r', 50)
+```
+
+The latter example requires breaking out of chaining and makes things less readable. With multiple calls like this, it could easily get ugly.
+
 <a name="selection_empty" href="#selection_empty">#</a> <i>selection</i>.<b>empty</b>() [<>](https://github.com/d3/d3-selection/blob/master/src/selection/empty.js "Source")
 
 Returns true if this selection contains no (non-null) elements.

--- a/src/selection/apply.js
+++ b/src/selection/apply.js
@@ -1,0 +1,5 @@
+export default function() {
+  var callback = arguments[0];
+  arguments[0] = this;
+  return callback.apply(null, arguments);
+}

--- a/src/selection/index.js
+++ b/src/selection/index.js
@@ -8,6 +8,7 @@ import selection_merge from "./merge";
 import selection_order from "./order";
 import selection_sort from "./sort";
 import selection_call from "./call";
+import selection_apply from "./apply";
 import selection_nodes from "./nodes";
 import selection_node from "./node";
 import selection_size from "./size";
@@ -52,6 +53,7 @@ Selection.prototype = selection.prototype = {
   order: selection_order,
   sort: selection_sort,
   call: selection_call,
+  apply: selection_apply,
   nodes: selection_nodes,
   node: selection_node,
   size: selection_size,

--- a/test/selection/apply-test.js
+++ b/test/selection/apply-test.js
@@ -1,0 +1,22 @@
+var tape = require("tape"),
+    jsdom = require("../jsdom"),
+    d3 = require("../../");
+
+tape("selection.apply(function) calls the specified function, passing the return value", function(test) {
+  var document = jsdom('<div id="test"></div>'),
+      selection = d3.select(document).select('#test');
+  test.deepEqual(selection.apply(function(selection) { 
+    return selection.append('div').attr('id', 'apply-test'); 
+  }), selection.select('#apply-test'));
+  test.end();
+});
+
+tape("selection.apply(function, arguments…) calls the specified function, passing the additional arguments", function(test) {
+  var id = 'custom-id',
+      document = jsdom('<div id="test"></div>'),
+      selection = d3.select(document).select('#test');
+  test.deepEqual(selection.apply(function(selection, id) { 
+    return selection.append('div').attr('id', id); 
+  }, id), selection.select('#' + id));
+  test.end();
+});


### PR DESCRIPTION
This is in response to issue #102, which requested a method like `call` that uses the return value of the called function instead of the original selection. 