### PR TITLE
dataAppend

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,6 +633,23 @@ You can expose the custom data attributes by setting each element’s data as th
 selection.datum(function() { return this.dataset; })
 ```
 
+<a name="dataAppend" href="#dataAppend">#</a> selection.<b>dataAppend</b>(<i>array</i>, <i>selector</i>) [<>](https://github.com/d3/d3-selection/blob/master/src/selection/dataAppend.js "Source")
+
+Syntactic sugar for making an empty selection, binding data to it, taking the enter selection and appending elements. 
+
+```js
+selection.dataAppend(myArray, 'div');
+```
+
+is equivalent to this: 
+
+```js
+selection.selectAll(null)
+  .data(myArray)
+  .enter()
+  .append('div');
+```
+
 ### Handling Events
 
 For interaction, selections allow listening for and dispatching of events.

--- a/src/selection/dataAppend.js
+++ b/src/selection/dataAppend.js
@@ -1,0 +1,3 @@
+export default function(data, name){
+  return this.selectAll(null).data(data).enter().append(name);
+}

--- a/src/selection/index.js
+++ b/src/selection/index.js
@@ -1,6 +1,7 @@
 import selection_select from "./select";
 import selection_selectAll from "./selectAll";
 import selection_filter from "./filter";
+import selection_dataAppend from "./dataAppend";
 import selection_data from "./data";
 import selection_enter from "./enter";
 import selection_exit from "./exit";
@@ -45,6 +46,7 @@ Selection.prototype = selection.prototype = {
   select: selection_select,
   selectAll: selection_selectAll,
   filter: selection_filter,
+  dataAppend: selection_dataAppend,
   data: selection_data,
   enter: selection_enter,
   exit: selection_exit,

--- a/test/selection/dataAppend-test.js
+++ b/test/selection/dataAppend-test.js
@@ -1,0 +1,17 @@
+var tape = require("tape"),
+    jsdom = require("../jsdom"),
+    d3 = require("../../");
+
+tape("selection.dataAppenddata, 'h1' returns a selection", function(test) {
+  var document = jsdom();
+  test.ok(d3.select(document.body).dataAppend([1, 2], "h1") instanceof d3.selection);
+  test.end();
+});
+
+tape("selection.dataAppend(array, 'h1') creates an element for element in the array ", function(test) {
+  var document = jsdom();
+  var selection = d3.select(document.body).dataAppend([1, 2], "h1")
+
+  test.deepEqual(selection.size(), 2);
+  test.end();
+});


### PR DESCRIPTION
Teaching d3 hits a roadblock when you create multiple elements. `select`, `style`, `append` work like jquery or `queryselector`, but this is trickier: 

```
selection.selectAll('div)
  .data(myArray)
  .enter()
  .append('div');
```

You have to slow down and carefully explain that you're selecting something that doesn't exist yet, binding data to that selection and appending an element to the selection. 

It is a lot to grasp! It usually ends up going about as well as explaining `public static void main(String[] args) {` in `HelloWorld.java`: 

> This is a magic incantation that we'll try to understand later... Let's get something on the screen first.

Which, in the context of d3, isn't a helpful attitude. Learning requires popping opening up the dev tools and figuring out some of what's going on under the hood.  

Adding `dataAppend` makes the API slightly parsimonious, but I think it'll make the learning curve gentler:

> `append` makes a single element. `dataAppend` makes an element for each item in your array, attaching items to their respective elements. 

By the time someone is curious about adding or removing elements to a selection, they'll have gotten practice with data binding. "Thinking with Joins" will be easier to digest.