### PR TITLE
Lazily initialize the matcher function for other environments like JSDOM

### DIFF
--- a/src/matcher.js
+++ b/src/matcher.js
@@ -1,22 +1,20 @@
 var matcher = function(selector) {
+  if (typeof document !== "undefined") {
+    var element = document.documentElement;
+    if (!element.matches) {
+      var vendorMatches = element.webkitMatchesSelector
+        || element.msMatchesSelector
+        || element.mozMatchesSelector
+        || element.oMatchesSelector;
+      return function() {
+        return vendorMatches.call(this, selector);
+      };
+    }
+  }
+
   return function() {
     return this.matches(selector);
   };
 };
-
-if (typeof document !== "undefined") {
-  var element = document.documentElement;
-  if (!element.matches) {
-    var vendorMatches = element.webkitMatchesSelector
-        || element.msMatchesSelector
-        || element.mozMatchesSelector
-        || element.oMatchesSelector;
-    matcher = function(selector) {
-      return function() {
-        return vendorMatches.call(this, selector);
-      };
-    };
-  }
-}
 
 export default matcher;


### PR DESCRIPTION
Fixes #181.