### PR TITLE
[Fix] Fix warning about using passive listeners

### DIFF
--- a/src/selection/on.js
+++ b/src/selection/on.js
@@ -62,12 +62,12 @@ function onAdd(typename, value, capture) {
     if (on) for (var j = 0, m = on.length; j < m; ++j) {
       if ((o = on[j]).type === typename.type && o.name === typename.name) {
         this.removeEventListener(o.type, o.listener, o.capture);
-        this.addEventListener(o.type, o.listener = listener, o.capture = capture);
-        o.value = value;
+        Object.assign(o, { listener, capture, value })
+        this.addEventListener(o.type, listener, { passive: false, capture: capture });
         return;
       }
     }
-    this.addEventListener(typename.type, listener, capture);
+    this.addEventListener(typename.type, listener, { passive: false, capture: capture });
     o = {type: typename.type, name: typename.name, value: value, listener: listener, capture: capture};
     if (!on) this.__on = [o];
     else on.push(o);


### PR DESCRIPTION
*Problem:* Modern browsers complain too much about using non-passive listeners.
*Expected*: No warnings when attaching listeners (especially designed to be non-passive)
*Reality*: Up to 10k warning messages in the console (in verbose mode). Likely these warnings will stay in production build too.
*Proposed fix*: Fix warning about using passive listeners by explicitly stating that non-passive listener is required.

PS:Also I made use of `Object.assign` to update properties of `o`, as it clearly indicates the intention.