### PR TITLE
[fix] correct listener options handling

### DIFF
--- a/src/selection/on.js
+++ b/src/selection/on.js
@@ -79,7 +79,7 @@ function onAdd(typename, value, options) {
   };
 }
 
-export default function(typename, value, capture) {
+export default function(typename, value, options) {
   var typenames = parseTypenames(typename + ""), i, n = typenames.length, t;
 
   if (arguments.length < 2) {
@@ -96,7 +96,7 @@ export default function(typename, value, capture) {
 
   on = value ? onAdd : onRemove;
   if (capture == null) capture = false;
-  for (i = 0; i < n; ++i) this.each(on(typenames[i], value, capture));
+  for (i = 0; i < n; ++i) this.each(on(typenames[i], value, options));
   return this;
 }
 

--- a/test/selection/on-test.js
+++ b/test/selection/on-test.js
@@ -31,9 +31,9 @@ tape("selection.on(type, listener) observes the specified name, if any", functio
 
 tape("selection.on(type, listener, capture) observes the specified capture flag, if any", function(test) {
   var result,
-      selection = d3.select({addEventListener: function(type, listener, capture) { result = capture; }});
+      selection = d3.select({addEventListener: function(type, listener, options) { result = options; }});
   test.equal(selection.on("click.foo", function() {}, true), selection);
-  test.deepEqual(result, true);
+  test.deepEqual(result.capture, true);
   test.end();
 });
 


### PR DESCRIPTION
Reworked #220
1. `options` instead of `capture` where appropriate.
2. onAdd coerces boolean `options` argument to an object.
3. onAdd rewritten for better readability: 
  - the loop in the original implementation basically meant `Array.prototype.find`
  - Adding listener happens unconditionally (de-duplicate corresponding code)
  - `this.__on` will anyway be an array at the end of `onAdd`, so get rid of excessive checks by assigning empty array if undefined.
  - Very simple to follow: the execution goes line by line.

See [this issue for d3-zoom](https://github.com/d3/d3-zoom/issues/103)

You proposed to lower the level of verbosity here, which seems more like sweeping a problem under the rug, rather than solving it.

> The main point of this PR is to always pass an object as options, because otherwise there will be warnings in the console, which are very hard to make sense of, namely:
> 
> [Violation] Add non-passive event listener to a scroll-blocking '<name of event>' event. Consider marking event handler as 'passive' to make the page more responsive.
> 
> This text says that you need handlers to be passive to get rid of warnings. That's not correct. The truth is --- you just need to specify explicitly whether it's passive or not --- and the warning will disappear.
> 
> So we need to coerce boolean value to an options object and provide default value for options.passive.