### PR TITLE
touch & pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,10 @@ If the *target* is an HTML element, the event’s coordinates are translated rel
 
 Otherwise, [*event*.pageX, *event*.pageY] is returned.
 
+<a name="pointers" href="#pointers">#</a> d3.<b>pointers</b>(<i>event</i>[, <i>target</i>]) [<>](https://github.com/d3/d3-selection/blob/master/src/pointer.js "Source")
+
+A generalization of [pointer](#pointer) for multitouch events. Returns the *x* and *y* coordinates of the specified *event*’s touches relative to the specified *target*, as an array of two-element arrays of numbers [[*x1, y1*], [*x2, y2*], …]. If *target* is not specified, it defaults to *event*.currentTarget.
+
 ### Control Flow
 
 For advanced usage, selections provide methods for custom control flow.

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ export {default as local} from "./local.js";
 export {default as matcher} from "./matcher.js";
 export {default as namespace} from "./namespace.js";
 export {default as namespaces} from "./namespaces.js";
-export {default as pointer} from "./pointer.js";
+export {default as pointer, pointers} from "./pointer.js";
 export {default as select} from "./select.js";
 export {default as selectAll} from "./selectAll.js";
 export {default as selection} from "./selection/index.js";

--- a/src/pointer.js
+++ b/src/pointer.js
@@ -1,4 +1,5 @@
-export default function(event, node = event.currentTarget) {
+export default function pointer(event, node = event.currentTarget) {
+  if (event instanceof TouchEvent) event = event.touches[0];
   if (node) {
     var svg = node.ownerSVGElement || node;
     if (svg.createSVGPoint) {
@@ -13,4 +14,8 @@ export default function(event, node = event.currentTarget) {
     }
   }
   return [event.pageX, event.pageY];
+}
+
+export function pointers(event, node = event.currentTarget) {
+  return Array.from(event.touches || [event]).map(e => pointer(e, node));
 }

--- a/src/pointer.js
+++ b/src/pointer.js
@@ -1,5 +1,5 @@
 export default function pointer(event, node = event.currentTarget) {
-  if (event instanceof TouchEvent) event = event.touches[0];
+  if (event instanceof TouchEvent) event = event.touches[0] || event.changedTouches[0];
   if (node) {
     var svg = node.ownerSVGElement || node;
     if (svg.createSVGPoint) {


### PR DESCRIPTION
[touches](https://developer.mozilla.org/en-US/docs/Web/API/Touch) don't offer a *currentTarget* property, which makes them difficult to handle here, e.g. d3.pointer(touch) doesn't work — without this proposal we'd have to write an explicit `d3.pointer(event.touches[0], event.currentTarget)`.

Hence this double change: one to make d3.pointer work with the first touch + introduction of d3.pointers to retrieve all the touches.

closes https://github.com/d3/d3-selection/issues/245