### PR TITLE
Fix regex bug in IE where parseTypenames didn't always work properly

### DIFF
--- a/src/selection/on.js
+++ b/src/selection/on.js
@@ -32,7 +32,7 @@ function contextListener(listener, index, group) {
 }
 
 function parseTypenames(typenames) {
-  return typenames.trim().split(/^|\s+/).map(function(t) {
+  return typenames.trim().split(/\s+/).filter(function(t) { return t; }).map(function(t) {
     var name = "", i = t.indexOf(".");
     if (i >= 0) name = t.slice(i + 1), t = t.slice(0, i);
     return {type: t, name: name};


### PR DESCRIPTION
Same issue/fix as here: https://github.com/d3/d3-dispatch/pull/23