### PR TITLE
Avoid assigning string into innerHTML

### DIFF
--- a/src/selection/html.js
+++ b/src/selection/html.js
@@ -1,5 +1,5 @@
 function htmlRemove() {
-  this.innerHTML = "";
+  this.textContent = "";
 }
 
 function htmlConstant(value) {
@@ -11,7 +11,11 @@ function htmlConstant(value) {
 function htmlFunction(value) {
   return function() {
     var v = value.apply(this, arguments);
-    this.innerHTML = v == null ? "" : v;
+    if (v == null) {
+      this.textContent = "";
+    } else {
+      this.innerHTML = v;
+    }
   };
 }
 

--- a/test/selection/html-test.js
+++ b/test/selection/html-test.js
@@ -20,21 +20,21 @@ tape("selection.html(value) sets inner HTML on the selected elements", function(
 });
 
 tape("selection.html(null) clears the inner HTML on the selected elements", function(test) {
-  var one = {innerHTML: "bar"},
-      two = {innerHTML: "bar"},
+  var one = {textContent: "bar"},
+      two = {textContent: "bar"},
       selection = d3.selectAll([one, two]);
   test.equal(selection.html(null), selection);
-  test.equal(one.innerHTML, "");
-  test.equal(two.innerHTML, "");
+  test.equal(one.textContent, "");
+  test.equal(two.textContent, "");
   test.end();
 });
 
 tape("selection.html(function) sets the value of the inner HTML on the selected elements", function(test) {
-  var one = {innerHTML: "bar"},
+  var one = {textContent: "bar"},
       two = {innerHTML: "bar"},
       selection = d3.selectAll([one, two]);
   test.equal(selection.html(function(d, i) { return i ? "baz" : null; }), selection);
-  test.equal(one.innerHTML, "");
+  test.equal(one.textContent, "");
   test.equal(two.innerHTML, "baz");
   test.end();
 });


### PR DESCRIPTION
[Trusted Types](https://web.dev/trusted-types/) don't allow assigning strings to `innerHTML` and other properties. This change avoids it by assigning the empty string to `textContent` which has the same effect.

An alternative solution would be to check if `trustedTypes` is available and use `trustedTypes.emptyHTML` if it is.