### PR TITLE
splitting string with original regex in ie11 fails

### DIFF
--- a/src/selection/classed.js
+++ b/src/selection/classed.js
@@ -1,5 +1,5 @@
 function classArray(string) {
-  return string.trim().split(/^|\s+/);
+  return string.trim().split(/\s+/);
 }
 
 function classList(node) {


### PR DESCRIPTION
The original implementation of the split regex causes the classname in IE11 to be splitted for every letter. 

Example: 
classArray("test") returns ['t','e','s','t',] instead of ['test']