### PR TITLE
Use changedTouches[0] if present in pointer

### DIFF
--- a/src/pointer.js
+++ b/src/pointer.js
@@ -2,6 +2,7 @@ import sourceEvent from "./sourceEvent.js";
 
 export default function(event, node) {
   event = sourceEvent(event);
+  if (event.changedTouches) event = event.changedTouches[0];
   if (node === undefined) node = event.currentTarget;
   if (node) {
     var svg = node.ownerSVGElement || node;


### PR DESCRIPTION
So I was dragging along and d3.pointer was working for me on desktop Chrome and Safari, but on mobile Safari, `clientX` and `clientY` were coming through `undefined`, leading `d3.pointer(event, this)` to return `[NaN, NaN]`. But it works with the old `d3.mouse(this)` approach, where [mouse.js](https://github.com/d3/d3-selection/blob/d858f005911970e8dd480dd3b0a9631b861680c9/src/mouse.js#L5-L6) has:

~~~js
var event = sourceEvent();
if (event.changedTouches) event = event.changedTouches[0];
~~~

But now in [pointer.js](https://github.com/d3/d3-selection/blob/master/src/pointer.js#L4), it's just:

~~~js
event = sourceEvent(event);
~~~

My example works if I add back the check for changedTouches. But maybe there was a good reason for getting rid of it, I don't know.

Examples: 

- [d3 v5 (working)](https://next.observablehq.com/d/c4f432db08af6a25)
- [d3 v6 (broken)](https://next.observablehq.com/d/1e9581c0740cfbb6)
- [d3 v6 (fixed)](https://next.observablehq.com/d/2d5e19f82f853922)