### PR TITLE
fix selectChildren so that they can be removed with selection.remove()

### DIFF
--- a/src/selection/selectChildren.js
+++ b/src/selection/selectChildren.js
@@ -3,7 +3,7 @@ import {childMatcher} from "../matcher.js";
 var filter = Array.prototype.filter;
 
 function children() {
-  return this.children;
+  return [...this.children];
 }
 
 function childrenFilter(match) {


### PR DESCRIPTION
The ParentNode property `children` is a read-only property that returns a ***live*** HTMLCollection which contains all of the child elements of the node upon which it was called. https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/children

`d3.select("svg").selectChildren().remove()` will not success.