### PR TITLE
selection.merge(transition)

### DIFF
--- a/src/selection/merge.js
+++ b/src/selection/merge.js
@@ -1,7 +1,8 @@
 import {Selection} from "./index.js";
 
-export default function(selection) {
-  if (!(selection instanceof Selection)) throw new Error("invalid merge");
+export default function(context) {
+  if (!(selection instanceof Selection) && !context.selection) throw new Error("invalid merge");
+  var selection = context.selection ? context.selection() : context;
 
   for (var groups0 = this._groups, groups1 = selection._groups, m0 = groups0.length, m1 = groups1.length, m = Math.min(m0, m1), merges = new Array(m0), j = 0; j < m; ++j) {
     for (var group0 = groups0[j], group1 = groups1[j], n = group0.length, merge = merges[j] = new Array(n), node, i = 0; i < n; ++i) {

--- a/src/selection/merge.js
+++ b/src/selection/merge.js
@@ -1,8 +1,8 @@
 import {Selection} from "./index.js";
 
 export default function(context) {
-  if (!(selection instanceof Selection) && !context.selection) throw new Error("invalid merge");
   var selection = context.selection ? context.selection() : context;
+  if (!(selection instanceof Selection)) throw new Error("invalid merge");
 
   for (var groups0 = this._groups, groups1 = selection._groups, m0 = groups0.length, m1 = groups1.length, m = Math.min(m0, m1), merges = new Array(m0), j = 0; j < m; ++j) {
     for (var group0 = groups0[j], group1 = groups1[j], n = group0.length, merge = merges[j] = new Array(n), node, i = 0; i < n; ++i) {

--- a/src/selection/merge.js
+++ b/src/selection/merge.js
@@ -1,7 +1,7 @@
 import {Selection} from "./index.js";
 
 export default function(context) {
-  var selection = (context && context.selection) ? context.selection() : context;
+  var selection = context.selection ? context.selection() : context;
   if (!(selection instanceof Selection)) throw new Error("invalid merge");
 
   for (var groups0 = this._groups, groups1 = selection._groups, m0 = groups0.length, m1 = groups1.length, m = Math.min(m0, m1), merges = new Array(m0), j = 0; j < m; ++j) {

--- a/src/selection/merge.js
+++ b/src/selection/merge.js
@@ -1,7 +1,7 @@
 import {Selection} from "./index.js";
 
 export default function(context) {
-  var selection = context.selection ? context.selection() : context;
+  var selection = (context && context.selection) ? context.selection() : context;
   if (!(selection instanceof Selection)) throw new Error("invalid merge");
 
   for (var groups0 = this._groups, groups1 = selection._groups, m0 = groups0.length, m1 = groups1.length, m = Math.min(m0, m1), merges = new Array(m0), j = 0; j < m; ++j) {


### PR DESCRIPTION
I ended up investing what it might take to implement #257 and the code change seemed relatively straightforward, so I'm submitting this draft PR as a first step towards maybe implementing the feature.

I realize the implementation is not the hard part here. The hard part is weighing the pros and cons of introducing more surface area to this API.

Pros:
 * Would simplify usage of `.join` with transitions (no need to use `.call`).
 * Backwards compatible.
 * Applies only to a ["deprecated API."](https://observablehq.com/@d3/general-update-pattern).

Cons:
 * Adds surface area to an API that many folks already find confusing to use, which may lead to more support effort.

Closes #257

Inspired by [d3-axis](https://github.com/d3/d3-axis/blob/master/src/axis.js#L52).