### PR TITLE
Simplify usage of selection.join with transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ svg.selectAll("circle")
 
 The selections returned by the *enter* and *update* functions are merged and then returned by *selection*.join.
 
-You also animate enter, update and exit by creating transitions inside the *enter*, *update* and *exit* functions. To avoid breaking the method chain, use *selection*.call to create transitions, or return an undefined enter or update selection to prevent merging: the return value of the *enter* and *update* functions specifies the two selections to merge and return by *selection*.join.
+You can animate enter, update and exit by creating transitions inside the *enter*, *update* and *exit* functions. If the *enter* and *update* functions return transitions, their underlying selections are merged and then returned by *selection*.join. The return value of the *exit* function is not used.
 
 For more, see the [*selection*.join notebook](https://observablehq.com/@d3/selection-join).
 

--- a/src/selection/join.js
+++ b/src/selection/join.js
@@ -3,5 +3,5 @@ export default function(onenter, onupdate, onexit) {
   enter = typeof onenter === "function" ? onenter(enter) : enter.append(onenter + "");
   if (onupdate != null) update = onupdate(update);
   if (onexit == null) exit.remove(); else onexit(exit);
-  return enter && update ? enter.merge(update).order() : update;
+  return enter && update ? enter.selection().merge(update.selection()).order() : update;
 }

--- a/src/selection/join.js
+++ b/src/selection/join.js
@@ -6,7 +6,10 @@ function(onenter, onupdate, onexit) {
   } else {
     enter = enter.append(onenter + "");
   }
-  if (onupdate != null) update = onupdate(update);
+  if (onupdate != null) {
+    update = onupdate(update);
+    if (update) update = update.selection();
+  }
   if (onexit == null) exit.remove(); else onexit(exit);
   return enter && update ? enter.merge(update).order() : update;
 }

--- a/src/selection/join.js
+++ b/src/selection/join.js
@@ -1,7 +1,15 @@
-export default function(onenter, onupdate, onexit) {
+function(onenter, onupdate, onexit) {
   var enter = this.enter(), update = this, exit = this.exit();
-  enter = typeof onenter === "function" ? onenter(enter) : enter.append(onenter + "");
-  if (onupdate != null) update = onupdate(update);
+  if (typeof onenter === "function") {
+    enter = onenter(enter);
+    if (enter) enter = enter.selection();
+  } else {
+    enter = enter.append(onenter + "");
+  }
+  if (onupdate != null) {
+    update = onupdate(update);
+    if (update) update = update.selection();
+  }
   if (onexit == null) exit.remove(); else onexit(exit);
-  return enter && update ? enter.selection().merge(update.selection()).order() : update;
+  return enter && update ? enter.merge(update).order() : update;
 }

--- a/src/selection/join.js
+++ b/src/selection/join.js
@@ -6,10 +6,7 @@ function(onenter, onupdate, onexit) {
   } else {
     enter = enter.append(onenter + "");
   }
-  if (onupdate != null) {
-    update = onupdate(update);
-    if (update) update = update.selection();
-  }
+  if (onupdate != null) update = onupdate(update);
   if (onexit == null) exit.remove(); else onexit(exit);
   return enter && update ? enter.merge(update).order() : update;
 }

--- a/src/selection/join.js
+++ b/src/selection/join.js
@@ -1,4 +1,4 @@
-function(onenter, onupdate, onexit) {
+export default function(onenter, onupdate, onexit) {
   var enter = this.enter(), update = this, exit = this.exit();
   if (typeof onenter === "function") {
     enter = onenter(enter);

--- a/test/selection/join-test.js
+++ b/test/selection/join-test.js
@@ -39,3 +39,21 @@ tape("selection.join(…) reorders nodes to match the data", function(test) {
   test.equal(document.body.innerHTML, "<p>0</p><p>3</p><p>1</p><p>2</p><p>4</p>");
   test.end();
 });
+
+function mockTransition(selection){
+  return {
+    selection: function() { return selection; }
+  }
+}
+
+tape("selection.join(enter, update, exit) allows callbacks to return a transition", function(test) {
+  var document = jsdom("<p>1</p><p>2</p>"),
+      p = d3.select(document.body).selectAll("p").datum(function() { return this.textContent; });
+  p = p.data([1, 3], d => d).join(
+    enter => mockTransition(enter.append("p").attr("class", "enter").text(d => d)),
+    update => mockTransition(update.attr("class", "update")),
+    exit => mockTransition(exit.attr("class", "exit"))
+  );
+  test.equal(document.body.innerHTML, "<p class=\"update\">1</p><p class=\"exit\">2</p><p class=\"enter\">3</p>");
+  test.end();
+});


### PR DESCRIPTION
Related to #257, an alternative to https://github.com/d3/d3-selection/pull/285, this change would allow `.join` to handle the case that transitions are returned by `onenter` and/or `onupdate`. It would support the same simplified usage documented in #257, but leave the behavior of `.merge` unchanged. Just putting this out there as an alternative to consider, as it targets the main pain point, rather than introducing new behavior in `.merge` to accomplish the same goal.

This works because of [selection.selection](https://github.com/d3/d3-selection#selection_selection).